### PR TITLE
Expose module-based interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,22 @@ libraryDependencies ++= Seq(
 
 Use the provided `RocksDB` wrapper:
 ```scala
+import zio.rocksdb
 import zio.rocksdb.RocksDB
+import java.nio.charset.StandardCharsets
 
-val result: Task[Option[Array[Byte]]] = 
-  RocksDB.open("/data/state").use { db =>
-    val key   = "key".getBytes(UTF_8)
-    val value = "value".getBytes(UTF_8)
-  
-    for {
-      _      <- db.put(key, value)
-      result <- db.get(key)
-    } yield result
-  }
+val key   = "key".getBytes(StandardCharsets.UTF_8)
+val value = "value".getBytes(StandardCharsets.UTF_8)
+
+val readWrite =
+  for {
+    _      <- rocksdb.put(key, value)
+    result <- rocksdb.get(key)
+  } yield result
+
+val result: Task[Option[Array[Byte]]] =
+  readWrite.provideManaged(RocksDB.Live.open("/data/state"))
 ```
-
-If you need a method which is not wrapped by the library, you can
-access the underlying `org.rocksdb.RocksDB` instance using the
-`RocksDB#db` field. Make sure to wrap all method calls with `zio.Task`!
 
 ## Getting help
 

--- a/src/main/scala/zio/rocksdb/RocksDB.scala
+++ b/src/main/scala/zio/rocksdb/RocksDB.scala
@@ -123,10 +123,10 @@ object RocksDB {
         (withDB(db), handles.asScala.toList)
       }.toManaged(_._1.rocksDB.close)
 
-    def open(path: String) =
+    def open(path: String): Managed[Throwable, RocksDB[Any]] =
       Task(withDB(jrocks.RocksDB.open(path))).toManaged(_.rocksDB.close)
 
-    def open(options: jrocks.Options, path: String) =
+    def open(options: jrocks.Options, path: String): Managed[Throwable, RocksDB[Any]] =
       Task(withDB(jrocks.RocksDB.open(options, path))).toManaged(_.rocksDB.close)
 
     private def withDB(db: jrocks.RocksDB): RocksDB[Any] =

--- a/src/main/scala/zio/rocksdb/RocksDB.scala
+++ b/src/main/scala/zio/rocksdb/RocksDB.scala
@@ -1,98 +1,76 @@
 package zio.rocksdb
 
-import java.{ util => ju }
+// import java.{ util => ju }
 import org.{ rocksdb => jrocks }
 import zio._
 import zio.stream._
 
-import scala.jdk.CollectionConverters._
+// import scala.jdk.CollectionConverters._
 
-case class RocksDB(db: jrocks.RocksDB) {
-  def delete(key: Array[Byte]) =
-    Task(db.delete(key))
-
-  def delete(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]) =
-    Task(db.delete(cfHandle, key))
-
-  def get(key: Array[Byte]) =
-    Task(Option(db.get(key)))
-
-  def get(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]) =
-    Task(Option(db.get(cfHandle, key)))
-
-  def multiGetAsList(keys: List[Array[Byte]]) =
-    Task(db.multiGetAsList(keys.asJava).asScala.toList.map(Option(_)))
-
-  def multiGetAsList(keysAndHandles: Map[Array[Byte], jrocks.ColumnFamilyHandle]) =
-    Task {
-      val (keys, handles) = keysAndHandles.toList.unzip
-      db.multiGetAsList(handles.asJava, keys.asJava).asScala.toList.map(Option(_))
-    }
-
-  private def drainIterator(it: jrocks.RocksIterator): Stream[Throwable, (Array[Byte], Array[Byte])] =
-    ZStream.fromEffect(Task(it.seekToFirst())).drain ++
-      ZStream.fromEffect(Task(it.isValid())).flatMap { valid =>
-        if (!valid) ZStream.empty
-        else
-          ZStream.fromEffect(Task(it.key() -> it.value())) ++ ZStream.fromPull {
-            Task {
-              it.next()
-
-              if (!it.isValid()) ZIO.fail(None)
-              else UIO(it.key() -> it.value())
-            }.mapError(Some(_)).flatten
-          }
-      }
-
-  def newIterator: Stream[Throwable, (Array[Byte], Array[Byte])] =
-    ZStream
-      .bracket(Task(db.newIterator()))(it => UIO(it.close()))
-      .flatMap(drainIterator)
-
-  def newIterator(cfHandle: jrocks.ColumnFamilyHandle): Stream[Throwable, (Array[Byte], Array[Byte])] =
-    ZStream
-      .bracket(Task(db.newIterator(cfHandle)))(it => UIO(it.close()))
-      .flatMap(drainIterator)
-
-  def newIterators(
-    cfHandles: List[jrocks.ColumnFamilyHandle]
-  ): Stream[Throwable, (jrocks.ColumnFamilyHandle, Stream[Throwable, (Array[Byte], Array[Byte])])] =
-    ZStream
-      .bracket(Task(db.newIterators(cfHandles.asJava)))(its => UIO.foreach(its.asScala)(it => UIO(it.close())))
-      .flatMap { its =>
-        ZStream.fromIterable {
-          cfHandles.zip(its.asScala.toList.map(drainIterator))
-        }
-      }
-
-  def put(key: Array[Byte], value: Array[Byte]) =
-    Task(db.put(key, value))
-
-  def put(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte], value: Array[Byte]) =
-    Task(db.put(cfHandle, key, value))
-
-  def close: UIO[Unit] = UIO(db.closeE())
+trait RocksDB {
+  val rocksdb: RocksDB.Service[Any]
 }
 
 object RocksDB {
-  def open(
-    options: jrocks.DBOptions,
-    path: String,
-    cfDescriptors: List[jrocks.ColumnFamilyDescriptor]
-  ): Managed[Throwable, (RocksDB, List[jrocks.ColumnFamilyHandle])] =
-    Task {
-      val handles = new ju.ArrayList[jrocks.ColumnFamilyHandle](cfDescriptors.size)
-      val db      = jrocks.RocksDB.open(options, path, cfDescriptors.asJava, handles)
+  trait Service[R] {
+    def close: URIO[R, Unit]
 
-      (new RocksDB(db), handles.asScala.toList)
-    }.toManaged(_._1.close)
+    def delete(key: Array[Byte]): RIO[R, Unit]
 
-  def open(path: String) =
-    Task(new RocksDB(jrocks.RocksDB.open(path))).toManaged(_.close)
+    def delete(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]): RIO[R, Unit]
 
-  def open(options: jrocks.Options, path: String) =
-    Task(new RocksDB(jrocks.RocksDB.open(options, path))).toManaged(_.close)
+    def get(key: Array[Byte]): RIO[R, Option[Array[Byte]]]
 
-  def listColumnFamilies(options: jrocks.Options, path: String) =
-    Task(jrocks.RocksDB.listColumnFamilies(options, path))
+    def get(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]): RIO[R, Option[Array[Byte]]]
+
+    def multiGetAsList(keys: List[Array[Byte]]): RIO[R, List[Option[Array[Byte]]]]
+
+    def multiGetAsList(keysAndHandles: Map[Array[Byte], jrocks.ColumnFamilyHandle]): RIO[R, List[Option[Array[Byte]]]]
+
+    def newIterator: ZStream[R, Throwable, (Array[Byte], Array[Byte])]
+
+    def newIterator(cfHandle: jrocks.ColumnFamilyHandle): ZStream[R, Throwable, (Array[Byte], Array[Byte])]
+
+    def newIterators(
+      cfHandles: List[jrocks.ColumnFamilyHandle]
+    ): ZStream[R, Throwable, (jrocks.ColumnFamilyHandle, Stream[Throwable, (Array[Byte], Array[Byte])])]
+
+    def put(key: Array[Byte], value: Array[Byte]): RIO[R, Unit]
+
+    def put(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte], value: Array[Byte]): RIO[R, Unit]
+  }
+
+  trait Live extends RocksDB {
+    override val rocksdb: Service[Any] =
+      new Service[Any] {
+        def close: UIO[Unit] = ???
+
+        def delete(key: Array[Byte]): Task[Unit] = ???
+
+        def delete(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]): Task[Unit] = ???
+
+        def get(key: Array[Byte]): Task[Option[Array[Byte]]] = ???
+
+        def get(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]): Task[Option[Array[Byte]]] = ???
+
+        def multiGetAsList(keys: List[Array[Byte]]): Task[List[Option[Array[Byte]]]] = ???
+
+        def multiGetAsList(
+          keysAndHandles: Map[Array[Byte], jrocks.ColumnFamilyHandle]
+        ): Task[List[Option[Array[Byte]]]] = ???
+
+        def newIterator: Stream[Throwable, (Array[Byte], Array[Byte])] = ???
+
+        def newIterator(cfHandle: jrocks.ColumnFamilyHandle): Stream[Throwable, (Array[Byte], Array[Byte])] = ???
+
+        def newIterators(
+          cfHandles: List[jrocks.ColumnFamilyHandle]
+        ): Stream[Throwable, (jrocks.ColumnFamilyHandle, Stream[Throwable, (Array[Byte], Array[Byte])])] = ???
+
+        def put(key: Array[Byte], value: Array[Byte]): Task[Unit] = ???
+
+        def put(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte], value: Array[Byte]): Task[Unit] = ???
+
+      }
+  }
 }

--- a/src/main/scala/zio/rocksdb/RocksDB.scala
+++ b/src/main/scala/zio/rocksdb/RocksDB.scala
@@ -111,6 +111,9 @@ object RocksDB {
   }
 
   object Live {
+    def listColumnFamilies(options: jrocks.Options, path: String): Task[List[Array[Byte]]] =
+      Task(jrocks.RocksDB.listColumnFamilies(options, path).asScala.toList)
+
     def open(
       options: jrocks.DBOptions,
       path: String,
@@ -133,8 +136,5 @@ object RocksDB {
       new RocksDB[Any] {
         override val rocksDB: Service[Any] = new RocksDB.Live(db)
       }
-
-    def listColumnFamilies(options: jrocks.Options, path: String) =
-      Task(jrocks.RocksDB.listColumnFamilies(options, path))
   }
 }

--- a/src/main/scala/zio/rocksdb/RocksDB.scala
+++ b/src/main/scala/zio/rocksdb/RocksDB.scala
@@ -1,14 +1,14 @@
 package zio.rocksdb
 
-// import java.{ util => ju }
+import java.{ util => ju }
 import org.{ rocksdb => jrocks }
 import zio._
 import zio.stream._
 
-// import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters._
 
-trait RocksDB {
-  val rocksdb: RocksDB.Service[Any]
+trait RocksDB[R] {
+  val rocksDB: RocksDB.Service[R]
 }
 
 object RocksDB {
@@ -40,37 +40,101 @@ object RocksDB {
     def put(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte], value: Array[Byte]): RIO[R, Unit]
   }
 
-  trait Live extends RocksDB {
-    override val rocksdb: Service[Any] =
-      new Service[Any] {
-        def close: UIO[Unit] = ???
+  final class Live private (db: jrocks.RocksDB) extends Service[Any] {
+    def close: UIO[Unit] =
+      UIO(db.closeE())
 
-        def delete(key: Array[Byte]): Task[Unit] = ???
+    def delete(key: Array[Byte]): Task[Unit] =
+      Task(db.delete(key))
 
-        def delete(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]): Task[Unit] = ???
+    def delete(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]): Task[Unit] =
+      Task(db.delete(cfHandle, key))
 
-        def get(key: Array[Byte]): Task[Option[Array[Byte]]] = ???
+    def get(key: Array[Byte]): Task[Option[Array[Byte]]] =
+      Task(Option(db.get(key)))
 
-        def get(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]): Task[Option[Array[Byte]]] = ???
+    def get(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]): Task[Option[Array[Byte]]] =
+      Task(Option(db.get(cfHandle, key)))
 
-        def multiGetAsList(keys: List[Array[Byte]]): Task[List[Option[Array[Byte]]]] = ???
+    def multiGetAsList(keys: List[Array[Byte]]): Task[List[Option[Array[Byte]]]] =
+      Task(db.multiGetAsList(keys.asJava).asScala.toList.map(Option(_)))
 
-        def multiGetAsList(
-          keysAndHandles: Map[Array[Byte], jrocks.ColumnFamilyHandle]
-        ): Task[List[Option[Array[Byte]]]] = ???
-
-        def newIterator: Stream[Throwable, (Array[Byte], Array[Byte])] = ???
-
-        def newIterator(cfHandle: jrocks.ColumnFamilyHandle): Stream[Throwable, (Array[Byte], Array[Byte])] = ???
-
-        def newIterators(
-          cfHandles: List[jrocks.ColumnFamilyHandle]
-        ): Stream[Throwable, (jrocks.ColumnFamilyHandle, Stream[Throwable, (Array[Byte], Array[Byte])])] = ???
-
-        def put(key: Array[Byte], value: Array[Byte]): Task[Unit] = ???
-
-        def put(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte], value: Array[Byte]): Task[Unit] = ???
-
+    def multiGetAsList(
+      keysAndHandles: Map[Array[Byte], jrocks.ColumnFamilyHandle]
+    ): Task[List[Option[Array[Byte]]]] =
+      Task {
+        val (keys, handles) = keysAndHandles.toList.unzip
+        db.multiGetAsList(handles.asJava, keys.asJava).asScala.toList.map(Option(_))
       }
+
+    private def drainIterator(it: jrocks.RocksIterator): Stream[Throwable, (Array[Byte], Array[Byte])] =
+      ZStream.fromEffect(Task(it.seekToFirst())).drain ++
+        ZStream.fromEffect(Task(it.isValid())).flatMap { valid =>
+          if (!valid) ZStream.empty
+          else
+            ZStream.fromEffect(Task(it.key() -> it.value())) ++ ZStream.fromPull {
+              Task {
+                it.next()
+
+                if (!it.isValid()) ZIO.fail(None)
+                else UIO(it.key() -> it.value())
+              }.mapError(Some(_)).flatten
+            }
+        }
+
+    def newIterator: Stream[Throwable, (Array[Byte], Array[Byte])] =
+      ZStream
+        .bracket(Task(db.newIterator()))(it => UIO(it.close()))
+        .flatMap(drainIterator)
+
+    def newIterator(cfHandle: jrocks.ColumnFamilyHandle): Stream[Throwable, (Array[Byte], Array[Byte])] =
+      ZStream
+        .bracket(Task(db.newIterator(cfHandle)))(it => UIO(it.close()))
+        .flatMap(drainIterator)
+
+    def newIterators(
+      cfHandles: List[jrocks.ColumnFamilyHandle]
+    ): Stream[Throwable, (jrocks.ColumnFamilyHandle, Stream[Throwable, (Array[Byte], Array[Byte])])] =
+      ZStream
+        .bracket(Task(db.newIterators(cfHandles.asJava)))(its => UIO.foreach(its.asScala)(it => UIO(it.close())))
+        .flatMap { its =>
+          ZStream.fromIterable {
+            cfHandles.zip(its.asScala.toList.map(drainIterator))
+          }
+        }
+
+    def put(key: Array[Byte], value: Array[Byte]): Task[Unit] =
+      Task(db.put(key, value))
+
+    def put(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte], value: Array[Byte]): Task[Unit] =
+      Task(db.put(cfHandle, key, value))
+  }
+
+  object Live {
+    def open(
+      options: jrocks.DBOptions,
+      path: String,
+      cfDescriptors: List[jrocks.ColumnFamilyDescriptor]
+    ): Managed[Throwable, (RocksDB[Any], List[jrocks.ColumnFamilyHandle])] =
+      Task {
+        val handles = new ju.ArrayList[jrocks.ColumnFamilyHandle](cfDescriptors.size)
+        val db      = jrocks.RocksDB.open(options, path, cfDescriptors.asJava, handles)
+
+        (withDB(db), handles.asScala.toList)
+      }.toManaged(_._1.rocksDB.close)
+
+    def open(path: String) =
+      Task(withDB(jrocks.RocksDB.open(path))).toManaged(_.rocksDB.close)
+
+    def open(options: jrocks.Options, path: String) =
+      Task(withDB(jrocks.RocksDB.open(options, path))).toManaged(_.rocksDB.close)
+
+    private def withDB(db: jrocks.RocksDB): RocksDB[Any] =
+      new RocksDB[Any] {
+        override val rocksDB: Service[Any] = new RocksDB.Live(db)
+      }
+
+    def listColumnFamilies(options: jrocks.Options, path: String) =
+      Task(jrocks.RocksDB.listColumnFamilies(options, path))
   }
 }

--- a/src/main/scala/zio/rocksdb/package.scala
+++ b/src/main/scala/zio/rocksdb/package.scala
@@ -1,0 +1,46 @@
+package zio
+
+import org.{ rocksdb => jrocks }
+import zio.stream.ZStream
+
+package object rocksdb extends RocksDB.Service[RocksDB] {
+  def close: URIO[RocksDB, Unit] =
+    URIO.accessM(_.rocksDB.close)
+
+  def delete(key: Array[Byte]): RIO[RocksDB, Unit] =
+    RIO.accessM(_.rocksDB.delete(key))
+
+  def delete(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]): RIO[RocksDB, Unit] =
+    RIO.accessM(_.rocksDB.delete(cfHandle, key))
+
+  def get(key: Array[Byte]): RIO[RocksDB, Option[Array[Byte]]] =
+    RIO.accessM(_.rocksDB.get(key))
+
+  def get(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte]): RIO[RocksDB, Option[Array[Byte]]] =
+    RIO.accessM(_.rocksDB.get(cfHandle, key))
+
+  def multiGetAsList(keys: List[Array[Byte]]): RIO[RocksDB, List[Option[Array[Byte]]]] =
+    RIO.accessM(_.rocksDB.multiGetAsList(keys))
+
+  def multiGetAsList(
+    keysAndHandles: Map[Array[Byte], jrocks.ColumnFamilyHandle]
+  ): RIO[RocksDB, List[Option[Array[Byte]]]] =
+    RIO.accessM(_.rocksDB.multiGetAsList(keysAndHandles))
+
+  def newIterator: ZStream[RocksDB, Throwable, (Array[Byte], Array[Byte])] =
+    ZStream.unwrap(ZIO.access[RocksDB](_.rocksDB.newIterator))
+
+  def newIterator(cfHandle: jrocks.ColumnFamilyHandle): ZStream[RocksDB, Throwable, (Array[Byte], Array[Byte])] =
+    ZStream.unwrap(ZIO.access[RocksDB](_.rocksDB.newIterator(cfHandle)))
+
+  def newIterators(
+    cfHandles: List[jrocks.ColumnFamilyHandle]
+  ): ZStream[RocksDB, Throwable, (jrocks.ColumnFamilyHandle, ZStream[RocksDB, Throwable, (Array[Byte], Array[Byte])])] =
+    ZStream.unwrap(ZIO.access[RocksDB](_.rocksDB.newIterators(cfHandles)))
+
+  def put(key: Array[Byte], value: Array[Byte]): RIO[RocksDB, Unit] =
+    RIO.accessM(_.rocksDB.put(key, value))
+
+  def put(cfHandle: jrocks.ColumnFamilyHandle, key: Array[Byte], value: Array[Byte]): RIO[RocksDB, Unit] =
+    RIO.accessM(_.rocksDB.put(cfHandle, key, value))
+}

--- a/src/test/scala/zio/rocksdb/RocksDBSpec.scala
+++ b/src/test/scala/zio/rocksdb/RocksDBSpec.scala
@@ -5,14 +5,65 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{ Files, Path }
 
 import org.rocksdb.Options
-import zio.{ Managed, Task, UIO }
+import zio.{ Managed, RIO, Task, UIO }
+import zio.rocksdb
 import zio.test._
 import zio.test.Assertion._
 
 import scala.jdk.CollectionConverters._
 
+object RocksDBSpec
+    extends DefaultRunnableSpec(
+      suite("RocksDB")(
+        testM("get/put") {
+          val key   = "key".getBytes(UTF_8)
+          val value = "value".getBytes(UTF_8)
+
+          val test =
+            for {
+              _      <- rocksdb.put(key, value)
+              result <- rocksdb.get(key)
+            } yield assert(result, isSome(equalTo(value)))
+
+          test.provideManaged(Utils.tempDB)
+        },
+        testM("delete") {
+          val key   = "key".getBytes(UTF_8)
+          val value = "value".getBytes(UTF_8)
+
+          val test =
+            for {
+              _      <- rocksdb.put(key, value)
+              before <- rocksdb.get(key)
+              _      <- rocksdb.delete(key)
+              after  <- rocksdb.get(key)
+            } yield assert(before, isSome(equalTo(value))) && assert(after, isNone)
+
+          test.provideManaged(Utils.tempDB)
+        },
+        testM("newIterator") {
+          val data = (1 to 10).map(i => (s"key$i", s"value$i")).toList
+
+          val test =
+            for {
+              _          <- RIO.foreach(data) { case (k, v) => rocksdb.put(k.getBytes(UTF_8), v.getBytes(UTF_8)) }
+              results    <- rocksdb.newIterator.runCollect
+              resultsStr = results.map { case (k, v) => new String(k, UTF_8) -> new String(v, UTF_8) }
+            } yield assert(resultsStr, hasSameElements(data))
+
+          test.provideManaged(Utils.tempDB)
+        }
+      )
+    )
+
 object Utils {
-  def tempDir: Managed[Throwable, Path] =
+  def tempDB: Managed[Throwable, RocksDB] =
+    tempDir.flatMap { dir =>
+      val opts = new Options().setCreateIfMissing(true)
+      RocksDB.Live.open(opts, dir.toAbsolutePath.toString)
+    }
+
+  private def tempDir: Managed[Throwable, Path] =
     Task(Files.createTempDirectory("zio-rocksdb")).toManaged { path =>
       UIO {
         Files
@@ -25,58 +76,4 @@ object Utils {
           .foreach(_.delete)
       }
     }
-
-  def tempDB: Managed[Throwable, RocksDB[Any]] = {
-    val opts = new Options().setCreateIfMissing(true)
-
-    Utils.tempDir
-      .flatMap(p => RocksDB.Live.open(opts, p.toAbsolutePath.toString))
-
-  }
 }
-
-object RocksDBSpec
-    extends DefaultRunnableSpec(
-      suite("RocksDB")(
-        testM("get/put") {
-          val key   = "key".getBytes(UTF_8)
-          val value = "value".getBytes(UTF_8)
-
-          Utils.tempDB.use { db =>
-            val rdb = db.rocksDB
-
-            for {
-              _      <- rdb.put(key, value)
-              result <- rdb.get(key)
-            } yield assert(result, isSome(equalTo(value)))
-          }
-        },
-        testM("delete") {
-          val key   = "key".getBytes(UTF_8)
-          val value = "value".getBytes(UTF_8)
-
-          Utils.tempDB.use { db =>
-            val rdb = db.rocksDB
-
-            for {
-              _      <- rdb.put(key, value)
-              before <- rdb.get(key)
-              _      <- rdb.delete(key)
-              after  <- rdb.get(key)
-            } yield assert(before, isSome(equalTo(value))) && assert(after, isNone)
-          }
-        },
-        testM("newIterator") {
-          Utils.tempDB.use { db =>
-            val rdb  = db.rocksDB
-            val data = (1 to 10).map(i => (s"key$i", s"value$i")).toList
-
-            for {
-              _          <- Task.foreach(data) { case (k, v) => rdb.put(k.getBytes(UTF_8), v.getBytes(UTF_8)) }
-              results    <- rdb.newIterator.runCollect
-              resultsStr = results.map { case (k, v) => new String(k, UTF_8) -> new String(v, UTF_8) }
-            } yield assert(resultsStr, hasSameElements(data))
-          }
-        }
-      )
-    )


### PR DESCRIPTION
Closes #4 

Note that the change hides the ability to extend the core functionality by using the underlying `db` directly. While I'm not super opinionated about it (in fact we can roll it back), it "feels" better to gradually wrap all methods (I know it's a large interface), than to leave that to users.