### PR TITLE
Get all open column family handles.

### DIFF
--- a/src/main/scala/zio/rocksdb/Operations.scala
+++ b/src/main/scala/zio/rocksdb/Operations.scala
@@ -58,4 +58,6 @@ abstract class Operations[R <: Has[S], S <: service.RocksDB](implicit tagged: Ta
 
   def dropColumnFamilies(columnFamilyHandles: List[ColumnFamilyHandle]): ZIO[R, Throwable, Unit] =
     db >>= (_.dropColumnFamilies(columnFamilyHandles))
+
+  def ownedColumnFamilyHandles(): ZIO[R, Throwable, List[ColumnFamilyHandle]] = db >>= (_.ownedColumnFamilyHandles())
 }

--- a/src/main/scala/zio/rocksdb/TransactionDB.scala
+++ b/src/main/scala/zio/rocksdb/TransactionDB.scala
@@ -4,7 +4,9 @@ import org.{ rocksdb => jrocks }
 import zio._
 
 object TransactionDB extends Operations[TransactionDB, service.TransactionDB] {
-  private final class Live private (db: jrocks.TransactionDB) extends RocksDB.Live(db, Nil) with service.TransactionDB {
+  private final class Live private (db: jrocks.TransactionDB)
+      extends RocksDB.Live(db, Nil, allColumnFamilyHandles = Ref.unsafeMake(Nil))
+      with service.TransactionDB {
     override def beginTransaction(writeOptions: jrocks.WriteOptions): ZManaged[Any, Throwable, service.Transaction] =
       Transaction.Live.begin(db, writeOptions)
 

--- a/src/main/scala/zio/rocksdb/service/RocksDB.scala
+++ b/src/main/scala/zio/rocksdb/service/RocksDB.scala
@@ -110,4 +110,9 @@ trait RocksDB {
    * Deletes ColumnFamilies given a list of ColumnFamilyHandles
    */
   def dropColumnFamilies(columnFamilyHandles: List[ColumnFamilyHandle]): Task[Unit]
+
+  /**
+   * Returns a list of all open ColumnFamilyHandles
+   */
+  def ownedColumnFamilyHandles(): Task[List[ColumnFamilyHandle]]
 }


### PR DESCRIPTION
In `zio-flow`, we need to get all open `ColumnFamilyHandles` of a `db` to then get the right `columnFamilyHandle` by name (In the implementation of `DurableIndexedLog`). 

In this [PR](https://github.com/zio/zio-flow/pull/131/files#diff-33ef3e8cc2095a0d1d7fb6685af4b291fe6adc470b66774e7ded078cd3ac2a34R33), we are currently using `initialHandles`. This needs to be replaced by a method that gets all open `ColumnFamilyHandles`

From my inspection, this is not supported by`facebook/rocksdb` `java API`. There is no straight-forward way to retrieve `ownedColumnFamilyHandles`. https://github.dev/facebook/rocksdb/blob/main/java/src/main/java/org/rocksdb/RocksDB.java#L41 

This PR makes the changes necessary to keep and retrieve a list of all `ColumnFamilyHandles`